### PR TITLE
Allow to select more ships than available without throwing an error

### DIFF
--- a/src/main/java/com/github/retro_game/retro_game/service/dto/SimplifiedEspionageReportDto.java
+++ b/src/main/java/com/github/retro_game/retro_game/service/dto/SimplifiedEspionageReportDto.java
@@ -17,11 +17,13 @@ public class SimplifiedEspionageReportDto {
   private final String token;
   private final int neededSmallCargoes;
   private final int neededLargeCargoes;
+  private final int neededEspionageProbes;
 
   public SimplifiedEspionageReportDto(long id, Date at, @Nullable Long enemyId, String enemyName,
                                       CoordinatesDto coordinates, int activity, ResourcesDto resources,
                                       @Nullable Long fleet, @Nullable Long defense, String token,
-                                      int neededSmallCargoes, int neededLargeCargoes) {
+                                      int neededSmallCargoes, int neededLargeCargoes,
+                                      int neededEspionageProbes) {
     this.id = id;
     this.at = at;
     this.enemyId = enemyId;
@@ -34,6 +36,7 @@ public class SimplifiedEspionageReportDto {
     this.token = token;
     this.neededSmallCargoes = neededSmallCargoes;
     this.neededLargeCargoes = neededLargeCargoes;
+    this.neededEspionageProbes = neededEspionageProbes;
   }
 
   public long getId() {
@@ -82,5 +85,9 @@ public class SimplifiedEspionageReportDto {
 
   public int getNeededLargeCargoes() {
     return neededLargeCargoes;
+  }
+
+  public int getNeededEspionageProbes() {
+    return neededEspionageProbes;
   }
 }

--- a/src/main/java/com/github/retro_game/retro_game/service/impl/FlightServiceImpl.java
+++ b/src/main/java/com/github/retro_game/retro_game/service/impl/FlightServiceImpl.java
@@ -654,12 +654,12 @@ class FlightServiceImpl implements FlightServiceInternal {
     ArrayList<FlightUnit> flightUnits = new ArrayList<>();
     for (Map.Entry<UnitKind, Integer> entry : units.entrySet()) {
       UnitKind kind = entry.getKey();
-      int count = entry.getValue();
       BodyUnit bodyUnit = bodyUnits.get(kind);
-      if (bodyUnit == null || bodyUnit.getCount() < count) {
+      if (bodyUnit == null) {
         logger.info("Sending fleet failed, not enough units: userId={} bodyId={}", userId, body.getId());
         throw new NotEnoughUnitsException();
       }
+      int count = Math.min(entry.getValue(), bodyUnit.getCount());
       if (bodyUnit.getCount() == count) {
         bodyUnitRepository.delete(bodyUnit);
       } else {

--- a/src/main/java/com/github/retro_game/retro_game/service/impl/ReportServiceImpl.java
+++ b/src/main/java/com/github/retro_game/retro_game/service/impl/ReportServiceImpl.java
@@ -675,11 +675,13 @@ class ReportServiceImpl implements ReportServiceInternal {
           neededCapacity / UnitItem.getFleet().get(UnitKind.SMALL_CARGO).getCapacity());
       int neededLargeCargoes = (int) Math.ceil(
           neededCapacity / UnitItem.getFleet().get(UnitKind.LARGE_CARGO).getCapacity());
+      int neededEspionageProbes = (int) Math.ceil(
+          neededCapacity / UnitItem.getFleet().get(UnitKind.ESPIONAGE_PROBE).getCapacity());
 
       simplifiedReports.add(new SimplifiedEspionageReportDto(report.getId(), report.getAt(), report.getEnemyId(),
           report.getEnemyName(), Converter.convert(report.getCoordinates()), report.getActivity(),
           Converter.convert(resources), report.getFleet(), report.getDefense(), token, neededSmallCargoes,
-          neededLargeCargoes));
+          neededLargeCargoes, neededEspionageProbes));
     }
     return simplifiedReports;
   }

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -260,6 +260,7 @@ productionDiff=Production diff
 productionFormat=Production (efficiency: {0}%)
 productionHourly=Production hourly
 productionWeekly=Production weekly
+raidWithEspionageProbes=Raid with espionage probes
 raidWithLargeCargoes=Raid with large cargoes
 raidWithSmallCargoes=Raid with small cargoes
 range=Range

--- a/src/main/resources/messages_pl.properties
+++ b/src/main/resources/messages_pl.properties
@@ -260,6 +260,7 @@ productionDiff=Różnica wydobycia
 productionFormat=Wydobycie (efektywność: {0}%)
 productionHourly=Godzinne wydobycie
 productionWeekly=Tygodniowe wydobycie
+raidWithEspionageProbes=Atakuj dużymi sonda szpiegowska
 raidWithLargeCargoes=Atakuj dużymi tranporterami
 raidWithSmallCargoes=Atakuj małymi tranporterami
 range=Zasięg

--- a/src/main/resources/templates/reports-espionage.html
+++ b/src/main/resources/templates/reports-espionage.html
@@ -92,6 +92,9 @@
         </td>
         <td class="report-actions">
           <a class="btn"
+             th:href="@{/flights/send(body=${bodyId},galaxy=${c.galaxy},system=${c.system},position=${c.position},kind=${c.kind},mission='ATTACK',units[ESPIONAGE_PROBE]=${report.neededEspionageProbes})}"
+             th:title="#{raidWithEspionageProbes}">EP</a>
+          <a class="btn"
              th:href="@{/flights/send(body=${bodyId},galaxy=${c.galaxy},system=${c.system},position=${c.position},kind=${c.kind},mission='ATTACK',units[SMALL_CARGO]=${report.neededSmallCargoes})}"
              th:title="#{raidWithSmallCargoes}">SC</a>
           <a class="btn"


### PR DESCRIPTION
A simple change to the send-fleet page. Now people using the report raid buttons shouldn't get an error if they do not have enough ships.
This change is necessary for the second commit:
Additionally add a raid button for espionage probes next to the other raid buttons (small & large cargo)