### PR TITLE
Highlight insufficient resources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@ target/
 # IntelliJ
 *.iml
 .idea/
+
+# Skins
+src/main/resources/public/static/skins/*
+!src/main/resources/public/static/skins/Empty

--- a/src/main/resources/templates/buildings.html
+++ b/src/main/resources/templates/buildings.html
@@ -79,13 +79,13 @@
         </p>
         <p th:with="cost=${building.cost}">
           <span th:text="#{metal}">Metal</span>:
-          <strong th:class="${r.metal < cost.metal ? 'requirement-not-met' : ''}"
+          <strong th:class="${r.metal < cost.metal ? 'requirement-not-met' : 'requirement-met'}"
                   th:text="${#numbers.formatInteger(cost.metal, 1, 'DEFAULT')}">200</strong>
           <span th:text="#{crystal}">Crystal</span>:
-          <strong th:class="${r.crystal < cost.crystal ? 'requirement-not-met' : ''}"
+          <strong th:class="${r.crystal < cost.crystal ? 'requirement-not-met' : 'requirement-met'}"
                   th:text="${#numbers.formatInteger(cost.crystal, 1, 'DEFAULT')}">50</strong>
           <span th:text="#{deuterium}">Deuterium</span>:
-          <strong th:class="${r.deuterium < cost.deuterium ? 'requirement-not-met' : ''}"
+          <strong th:class="${r.deuterium < cost.deuterium ? 'requirement-not-met' : 'requirement-met'}"
                   th:text="${#numbers.formatInteger(cost.deuterium, 1, 'DEFAULT')}">0</strong>
           <th:block th:if="${building.requiredEnergy > 0}">
             <span th:text="#{energy}">Energy</span>:

--- a/src/main/resources/templates/shipyard.html
+++ b/src/main/resources/templates/shipyard.html
@@ -57,13 +57,13 @@
         </p>
         <p th:with="cost=${unit.cost}">
           <span th:text="#{metal}">Metal</span>:
-          <strong th:class="${r.metal < cost.metal ? 'requirement-not-met' : ''}"
+          <strong th:class="${r.metal < cost.metal ? 'requirement-not-met' : 'requirement-met'}"
                   th:text="${#numbers.formatInteger(cost.metal, 1, 'DEFAULT')}">200</strong>
           <span th:text="#{crystal}">Crystal</span>:
-          <strong th:class="${r.crystal < cost.crystal ? 'requirement-not-met' : ''}"
+          <strong th:class="${r.crystal < cost.crystal ? 'requirement-not-met' : 'requirement-met'}"
                   th:text="${#numbers.formatInteger(cost.crystal, 1, 'DEFAULT')}">50</strong>
           <span th:text="#{deuterium}">Deuterium</span>:
-          <strong th:class="${r.deuterium < cost.deuterium ? 'requirement-not-met' : ''}"
+          <strong th:class="${r.deuterium < cost.deuterium ? 'requirement-not-met' : 'requirement-met'}"
                   th:text="${#numbers.formatInteger(cost.deuterium, 1, 'DEFAULT')}">0</strong>
         </p>
         <p>

--- a/src/main/resources/templates/technologies.html
+++ b/src/main/resources/templates/technologies.html
@@ -5,7 +5,7 @@
   <title th:text="#{technologies}">Technologies</title>
 </head>
 <body>
-<div layout:fragment="content">
+<div layout:fragment="content" th:with="production=${@bodyService.getProduction(bodyId)}">
   <table th:unless="${#lists.isEmpty(pair.queue)}">
     <tr>
       <th>#</th>
@@ -82,17 +82,18 @@
         <p th:text="#{${'items.' + technology.kind + '.description'}}"></p>
         <p th:with="cost=${technology.cost}">
           <span th:text="#{metal}">Metal</span>:
-          <strong th:class="${r.metal < cost.metal ? 'requirement-not-met' : ''}"
+          <strong th:class="${r.metal < cost.metal ? 'requirement-not-met' : 'requirement-met'}"
                   th:text="${#numbers.formatInteger(cost.metal, 1, 'DEFAULT')}">200</strong>
           <span th:text="#{crystal}">Crystal</span>:
-          <strong th:class="${r.crystal < cost.crystal ? 'requirement-not-met' : ''}"
+          <strong th:class="${r.crystal < cost.crystal ? 'requirement-not-met' : 'requirement-met'}"
                   th:text="${#numbers.formatInteger(cost.crystal, 1, 'DEFAULT')}">50</strong>
           <span th:text="#{deuterium}">Deuterium</span>:
-          <strong th:class="${r.deuterium < cost.deuterium ? 'requirement-not-met' : ''}"
+          <strong th:class="${r.deuterium < cost.deuterium ? 'requirement-not-met' : 'requirement-met'}"
                   th:text="${#numbers.formatInteger(cost.deuterium, 1, 'DEFAULT')}">0</strong>
           <th:block th:if="${technology.requiredEnergy > 0}">
             <span th:text="#{energy}">Energy</span>:
-            <strong th:text="${#numbers.formatInteger(technology.requiredEnergy, 1, 'DEFAULT')}">200</strong>
+            <strong th:class="${production.totalEnergy < technology.requiredEnergy ? 'requirement-not-met' : 'requirement-met'}"
+                    th:text="${#numbers.formatInteger(technology.requiredEnergy, 1, 'DEFAULT')}">200</strong>
           </th:block>
         </p>
         <p>


### PR DESCRIPTION
Highlight insufficient resources in buildings/researches/ships/defenses red. Works also with energy for graviton. If you are using any other skin that default Empty, you need to provide CSS for sufficient and insufficient resources in your skins style.css. Like this:

```
.requirement-not-met {
  color: red;
}

.requirement-met {
  color: #8f0;
}
```

This way you can also customize the colors, font, etc.

I also added `src/main/resources/public/static/skins/*` to `.gitignore` with exception of Empty skin so other skins can't be accidently commited.