### PR TITLE
Allow building nanites on the moon

### DIFF
--- a/config/application.properties
+++ b/config/application.properties
@@ -86,3 +86,5 @@ retro-game.defense-rebuild-factor=0.7
 retro-game.fleet-debris-factor=0.3
 retro-game.defense-debris-factor=0.0
 retro-game.max-moon-chance=0.2
+# Extra features
+retro-game.allow-nanites-on-moons=false

--- a/src/main/java/com/github/retro_game/retro_game/model/building/NaniteFactory.java
+++ b/src/main/java/com/github/retro_game/retro_game/model/building/NaniteFactory.java
@@ -23,11 +23,6 @@ public class NaniteFactory extends BuildingItem {
   }
 
   @Override
-  public boolean meetsSpecialRequirements(Body body) {
-    return body.getCoordinates().getKind() == CoordinatesKind.PLANET;
-  }
-
-  @Override
   public Resources getBaseCost() {
     return new Resources(1000000.0, 500000.0, 100000.0);
   }


### PR DESCRIPTION
Can be turned on/off in `application.properties` with flag `retro-game.allow-nanites-on-moons`. By default set to `false`.