### PR TITLE
Allow augmenting production with plasma technology

### DIFF
--- a/config/application.properties
+++ b/config/application.properties
@@ -70,6 +70,7 @@ retro-game.deuterium-synthesizer-base-energy-usage=20
 retro-game.solar-plant-base-energy-production=20
 retro-game.fusion-reactor-base-energy-production=30
 retro-game.fusion-reactor-base-deuterium-usage=10
+retro-game.plasma-technology-affects-production=false
 # Queue capacities
 retro-game.building-queue-capacity=10
 retro-game.technology-queue-capacity=10

--- a/src/main/java/com/github/retro_game/retro_game/service/impl/BodyServiceImpl.java
+++ b/src/main/java/com/github/retro_game/retro_game/service/impl/BodyServiceImpl.java
@@ -863,9 +863,9 @@ class BodyServiceImpl implements BodyServiceInternal {
     // Calculate bonus from plasma technology if enabled
     if (plasmaAffectsProduction) {
       var plasmaTechLevel = body.getUser().getTechnologyLevel(TechnologyKind.PLASMA_TECHNOLOGY);
-      metalMineProduction = metalMineProduction * plasmaTechLevel / 100;
-      crystalMineProduction = (int) Math.round(crystalMineProduction * plasmaTechLevel * 0.0066);
-      deuteriumSynthesizerProduction = (int) Math.round(deuteriumSynthesizerProduction * plasmaTechLevel * 0.0033);
+      metalMineProduction = (int) Math.round(metalMineProduction * plasmaTechLevel * 0.01) + metalMineProduction;
+      crystalMineProduction = (int) Math.round(crystalMineProduction * plasmaTechLevel * 0.0066) + crystalMineProduction;
+      deuteriumSynthesizerProduction = (int) Math.round(deuteriumSynthesizerProduction * plasmaTechLevel * 0.0033) + deuteriumSynthesizerProduction;
     }
 
     // Solar plant.

--- a/src/main/java/com/github/retro_game/retro_game/service/impl/BodyServiceImpl.java
+++ b/src/main/java/com/github/retro_game/retro_game/service/impl/BodyServiceImpl.java
@@ -58,7 +58,7 @@ class BodyServiceImpl implements BodyServiceInternal {
   private final int fieldsPerTerraformerLevel;
   private final int fieldsPerLunarBaseLevel;
   private final int storageCapacityMultiplier;
-  private final boolean plasmaAffectsProduction;
+  private final boolean plasmaTechnologyAffectsProduction;
   private final CacheObserver cacheObserver;
   private final BodyInfoCache bodyInfoCache;
   private final UserInfoCache userInfoCache;
@@ -88,7 +88,7 @@ class BodyServiceImpl implements BodyServiceInternal {
                          @Value("${retro-game.fields-per-terraformer-level}") int fieldsPerTerraformerLevel,
                          @Value("${retro-game.fields-per-lunar-base-level}") int fieldsPerLunarBaseLevel,
                          @Value("${retro-game.storage-capacity-multiplier}") int storageCapacityMultiplier,
-                         @Value("${retro-game.plasma-technology-affects-production}") boolean plasmaAffectsProduction,
+                         @Value("${retro-game.plasma-technology-affects-production}") boolean plasmaTechnologyAffectsProduction,
                          CacheObserver cacheObserver,
                          BodyInfoCache bodyInfoCache,
                          UserInfoCache userInfoCache,
@@ -113,7 +113,7 @@ class BodyServiceImpl implements BodyServiceInternal {
     this.fieldsPerTerraformerLevel = fieldsPerTerraformerLevel;
     this.fieldsPerLunarBaseLevel = fieldsPerLunarBaseLevel;
     this.storageCapacityMultiplier = storageCapacityMultiplier;
-    this.plasmaAffectsProduction = plasmaAffectsProduction;
+    this.plasmaTechnologyAffectsProduction = plasmaTechnologyAffectsProduction;
     this.cacheObserver = cacheObserver;
     this.bodyInfoCache = bodyInfoCache;
     this.userInfoCache = userInfoCache;
@@ -861,7 +861,7 @@ class BodyServiceImpl implements BodyServiceInternal {
         deuteriumSynthesizerLevel * Math.pow(1.1, deuteriumSynthesizerLevel) * deuteriumSynthesizerFactor);
 
     // Calculate bonus from plasma technology if enabled
-    if (plasmaAffectsProduction) {
+    if (plasmaTechnologyAffectsProduction) {
       var plasmaTechLevel = body.getUser().getTechnologyLevel(TechnologyKind.PLASMA_TECHNOLOGY);
       metalMineProduction = (int) Math.round(metalMineProduction * plasmaTechLevel * 0.01) + metalMineProduction;
       crystalMineProduction = (int) Math.round(crystalMineProduction * plasmaTechLevel * 0.0066) + crystalMineProduction;

--- a/src/main/java/com/github/retro_game/retro_game/service/impl/BodyServiceImpl.java
+++ b/src/main/java/com/github/retro_game/retro_game/service/impl/BodyServiceImpl.java
@@ -58,6 +58,7 @@ class BodyServiceImpl implements BodyServiceInternal {
   private final int fieldsPerTerraformerLevel;
   private final int fieldsPerLunarBaseLevel;
   private final int storageCapacityMultiplier;
+  private final boolean plasmaAffectsProduction;
   private final CacheObserver cacheObserver;
   private final BodyInfoCache bodyInfoCache;
   private final UserInfoCache userInfoCache;
@@ -87,6 +88,7 @@ class BodyServiceImpl implements BodyServiceInternal {
                          @Value("${retro-game.fields-per-terraformer-level}") int fieldsPerTerraformerLevel,
                          @Value("${retro-game.fields-per-lunar-base-level}") int fieldsPerLunarBaseLevel,
                          @Value("${retro-game.storage-capacity-multiplier}") int storageCapacityMultiplier,
+                         @Value("${retro-game.plasma-technology-affects-production}") boolean plasmaAffectsProduction,
                          CacheObserver cacheObserver,
                          BodyInfoCache bodyInfoCache,
                          UserInfoCache userInfoCache,
@@ -111,6 +113,7 @@ class BodyServiceImpl implements BodyServiceInternal {
     this.fieldsPerTerraformerLevel = fieldsPerTerraformerLevel;
     this.fieldsPerLunarBaseLevel = fieldsPerLunarBaseLevel;
     this.storageCapacityMultiplier = storageCapacityMultiplier;
+    this.plasmaAffectsProduction = plasmaAffectsProduction;
     this.cacheObserver = cacheObserver;
     this.bodyInfoCache = bodyInfoCache;
     this.userInfoCache = userInfoCache;
@@ -856,6 +859,14 @@ class BodyServiceImpl implements BodyServiceInternal {
         deuteriumSynthesizerFactor) * productionSpeed;
     int deuteriumSynthesizerMaxEnergyUsage = (int) Math.ceil(deuteriumSynthesizerBaseEnergyUsage *
         deuteriumSynthesizerLevel * Math.pow(1.1, deuteriumSynthesizerLevel) * deuteriumSynthesizerFactor);
+
+    // Calculate bonus from plasma technology if enabled
+    if (plasmaAffectsProduction) {
+      var plasmaTechLevel = body.getUser().getTechnologyLevel(TechnologyKind.PLASMA_TECHNOLOGY);
+      metalMineProduction = metalMineProduction * plasmaTechLevel / 100;
+      crystalMineProduction = (int) Math.round(crystalMineProduction * plasmaTechLevel * 0.0066);
+      deuteriumSynthesizerProduction = (int) Math.round(deuteriumSynthesizerProduction * plasmaTechLevel * 0.0033);
+    }
 
     // Solar plant.
     int solarPlantLevel = items.getSolarPlantLevel();


### PR DESCRIPTION
Add ability for plasma technology to augment resource production. Multiplier is 0.01 per level of plasma technology for metal, 0.0066 for crystal and 0.0033 for deuterium as stated [here](https://ogame.fandom.com/wiki/Plasma_Technology). Can be toggled in `application.properties` with boolean flag `retro-game.plasma-technology-affects-production`