### PR TITLE
Disallow unit construction when nanites or shipyard are being upgraded

### DIFF
--- a/src/main/java/com/github/retro_game/retro_game/service/impl/BuildingsServiceImpl.java
+++ b/src/main/java/com/github/retro_game/retro_game/service/impl/BuildingsServiceImpl.java
@@ -255,6 +255,11 @@ public class BuildingsServiceImpl implements BuildingsServiceInternal {
       var canConstructNow = hasEnoughFields && isQueueNotFull && meetsRequirements &&
           (queueSize > 0 || (hasEnoughResources && hasEnoughEnergy));
 
+      // If there is any construction in shipyard it should not be possible to build nanites or shipyard
+      if ((kind == BuildingKind.SHIPYARD || kind == BuildingKind.NANITE_FACTORY) && !body.getShipyardQueue().isEmpty()) {
+        canConstructNow = false;
+      }
+
       buildings.add(
           new BuildingDto(Converter.convert(kind), currentLevel, futureLevel, Converter.convert(cost), requiredEnergy,
               constructionTime, Converter.convert(missingResources), neededSmallCargoes, neededLargeCargoes,

--- a/src/main/java/com/github/retro_game/retro_game/service/impl/ShipyardServiceImpl.java
+++ b/src/main/java/com/github/retro_game/retro_game/service/impl/ShipyardServiceImpl.java
@@ -22,6 +22,9 @@ import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import static com.github.retro_game.retro_game.entity.BuildingKind.NANITE_FACTORY;
+import static com.github.retro_game.retro_game.entity.BuildingKind.SHIPYARD;
+
 @Service
 public class ShipyardServiceImpl implements ShipyardServiceInternal {
   private static final Logger logger = LoggerFactory.getLogger(ShipyardServiceImpl.class);
@@ -130,8 +133,14 @@ public class ShipyardServiceImpl implements ShipyardServiceInternal {
       var neededLargeCargoes = ItemUtils.calcNumUnitsForCapacity(UnitKind.LARGE_CARGO, missingResources);
       var accumulationTime = ItemTimeUtils.calcAccumulationTime(body.getUpdatedAt(), missingResources, production);
 
+      var shipyardOrNanitesInConstruction = false;
+      if (!body.getBuildingQueue().isEmpty()) {
+        var nowInConstruction = body.getBuildingQueue().get(body.getBuildingQueue().firstKey()).kind();
+        shipyardOrNanitesInConstruction = nowInConstruction == NANITE_FACTORY || nowInConstruction == SHIPYARD;
+      }
+
       var maxBuildable = 0;
-      if (meetsRequirements) {
+      if (meetsRequirements && !shipyardOrNanitesInConstruction) {
         maxBuildable = Integer.MAX_VALUE;
 
         if (cost.getMetal() > 0.0) {
@@ -363,8 +372,8 @@ public class ShipyardServiceImpl implements ShipyardServiceInternal {
   }
 
   private long getConstructionTime(Resources cost, Body body) {
-    int shipyardLevel = body.getBuildingLevel(BuildingKind.SHIPYARD);
-    int naniteFactoryLevel = body.getBuildingLevel(BuildingKind.NANITE_FACTORY);
+    int shipyardLevel = body.getBuildingLevel(SHIPYARD);
+    int naniteFactoryLevel = body.getBuildingLevel(NANITE_FACTORY);
     return itemTimeUtils.getUnitConstructionTime(cost, shipyardLevel, naniteFactoryLevel);
   }
 }


### PR DESCRIPTION
Units can't be constructed when nanites or shipyard are being upgraded and shipyard and nanites can't be upgraded when units are being built.
This should be done for research lab and technologies as well but that is kind of tricky.