### PR TITLE
Fix issue with input length 1 error on building application 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -122,6 +122,17 @@
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-resources-plugin</artifactId>
+        <version>3.2.0</version>
+        <configuration>
+          <propertiesEncoding>UTF-8</propertiesEncoding>
+          <nonFilteredFileExtensions>
+            <nonFilteredFileExtension>webp</nonFilteredFileExtension>
+          </nonFilteredFileExtensions>
+        </configuration>
+      </plugin>
     </plugins>
     <resources>
       <resource>


### PR DESCRIPTION
When binary files present in resources maven-resources-plugin fails with `Input length 1` error. Proposed to ignore all binary files in `pom.xml`, currently `webp`.