### PR TITLE
Keyboard navigation

### DIFF
--- a/src/main/resources/public/static/js/body-keyboard-navigation.js
+++ b/src/main/resources/public/static/js/body-keyboard-navigation.js
@@ -1,0 +1,16 @@
+'use strict';
+
+$(document).on('keydown', function (event) {
+  switch (event.which) {
+    case 37: // left arrow
+      if($('#top-bar-prev > button').is(':enabled')){
+        $('#top-bar-prev').submit();
+      }
+      break;
+    case 39: // right arrow
+      if($('#top-bar-next > button').is(':enabled')){
+        $('#top-bar-next').submit();
+      }
+      break;
+  }
+});

--- a/src/main/resources/templates/buildings.html
+++ b/src/main/resources/templates/buildings.html
@@ -104,6 +104,7 @@
       </td>
     </tr>
   </table>
+  <script th:src="@{/static/js/body-keyboard-navigation.js?{v}(v=${version})}"></script>
 </div>
 </body>
 </html>

--- a/src/main/resources/templates/empire.html
+++ b/src/main/resources/templates/empire.html
@@ -243,6 +243,7 @@
       </tr>
     </table>
   </form>
+  <script th:src="@{/static/js/body-keyboard-navigation.js?{v}(v=${version})}"></script>
 </div>
 </body>
 </html>

--- a/src/main/resources/templates/flights-send.html
+++ b/src/main/resources/templates/flights-send.html
@@ -212,6 +212,7 @@
     </table>
   </form>
   <script th:src="@{/static/js/send-fleet.js?{v}(v=${version})}"></script>
+  <script th:src="@{/static/js/body-keyboard-navigation.js?{v}(v=${version})}"></script>
 </div>
 </body>
 </html>

--- a/src/main/resources/templates/flights.html
+++ b/src/main/resources/templates/flights.html
@@ -86,6 +86,7 @@
       </td>
     </tr>
   </table>
+  <script th:src="@{/static/js/body-keyboard-navigation.js?{v}(v=${version})}"></script>
 </div>
 </body>
 </html>

--- a/src/main/resources/templates/overview.html
+++ b/src/main/resources/templates/overview.html
@@ -113,6 +113,7 @@
       </td>
     </tr>
   </table>
+  <script th:src="@{/static/js/body-keyboard-navigation.js?{v}(v=${version})}"></script>
 </div>
 </body>
 </html>

--- a/src/main/resources/templates/resources.html
+++ b/src/main/resources/templates/resources.html
@@ -193,6 +193,7 @@
       <td th:text="${#dates.format(deuteriumFullAt, 'yyyy-MM-dd HH:mm:ss')}"></td>
     </tr>
   </table>
+  <script th:src="@{/static/js/body-keyboard-navigation.js?{v}(v=${version})}"></script>
 </div>
 </body>
 </html>

--- a/src/main/resources/templates/shipyard.html
+++ b/src/main/resources/templates/shipyard.html
@@ -104,6 +104,7 @@
       <td th:text="#{youHaveToConstructShipyardFirst}">You have to construct a Shipyard first!</td>
     </tr>
   </table>
+  <script th:src="@{/static/js/body-keyboard-navigation.js?{v}(v=${version})}"></script>
 </div>
 </body>
 </html>

--- a/src/main/resources/templates/technologies.html
+++ b/src/main/resources/templates/technologies.html
@@ -110,6 +110,7 @@
       <td th:text="#{youHaveToConstructResearchLabFirst}">You have to construct a Research Lab first!</td>
     </tr>
   </table>
+  <script th:src="@{/static/js/body-keyboard-navigation.js?{v}(v=${version})}"></script>
 </div>
 </body>
 </html>

--- a/src/main/resources/templates/top-bar.html
+++ b/src/main/resources/templates/top-bar.html
@@ -23,7 +23,7 @@
                      th:name="${entry.key}" type="hidden" th:value="${entry.value[0]}">
             </form>
             <div id="top-bar-body-pointers" th:with="pointers=${ctx.curBodyPointers}">
-              <form th:with="info=${pointers.previous}">
+              <form id="top-bar-prev" th:with="info=${pointers.previous}">
                 <input name="body" type="hidden" th:value="${info?.id}">
                 <input th:each="entry : ${#request.getParameterMap()}" th:unless="${entry.key} == 'body'"
                        th:name="${entry.key}" type="hidden" th:value="${entry.value[0]}">
@@ -32,7 +32,7 @@
                   ←
                 </button>
               </form>
-              <form th:with="info=${pointers.next}">
+              <form id="top-bar-next" th:with="info=${pointers.next}">
                 <input name="body" type="hidden" th:value="${info?.id}">
                 <input th:each="entry : ${#request.getParameterMap()}" th:unless="${entry.key} == 'body'"
                        th:name="${entry.key}" type="hidden" th:value="${entry.value[0]}">


### PR DESCRIPTION
Added simple JavaScript to allow using arrow keys to switch to previous/next body. To use it I put it in several places, where I thought it made sense, like:
- Overview
- Flights (both overview and send)
- Shipyard
- Technologies

It would obviously be better to include it in `top-bar.html` but than it would clash with galaxy keyboard navigation so I chose this approach.